### PR TITLE
Bump python from 3.6-alpine to 3.7.2-alpine

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.6-alpine
+FROM python:3.7.2-alpine
 
 RUN addgroup -S app && adduser -S -g app app
 WORKDIR /usr/src/app


### PR DESCRIPTION
Bumps python from 3.6-alpine to 3.7.2-alpine.

Signed-off-by: dependabot[bot] <support@dependabot.com>